### PR TITLE
Add the ability to insert config sections directly

### DIFF
--- a/chart/kubed/templates/secret.yaml
+++ b/chart/kubed/templates/secret.yaml
@@ -42,6 +42,9 @@ recycleBin:
   path: /tmp/kubed/trash
   ttl: 168h0m0s
 {{- end }}
+{{- if .Values.config.include }}
+{{ .Values.config.include | toYaml }}
+{{- end }}
 {{ end }}
 
 apiVersion: v1

--- a/chart/kubed/values.yaml
+++ b/chart/kubed/values.yaml
@@ -83,3 +83,13 @@ config:
   enableConfigSyncer: true
   enableEventForwarder: false
   enableRecycleBin: true
+
+  # so you can include any other config required for kubed directly
+#  include:
+#    snapshotter:
+#      gcs:
+#          bucket: bucket-for-snapshot
+#          prefix: minikube
+#          storageSecretName: gcs-secret
+#      sanitize: true
+#      schedule: '@every 6h'


### PR DESCRIPTION
Without this ability extra config secrets need to be configured
manually and in an all-helm environment that means an extra chart just
to add a secret. With this addition the config can be put in a local
values file and be used directly by kubed along with the other config
here.